### PR TITLE
2022_10.md

### DIFF
--- a/archive/2022_10.md
+++ b/archive/2022_10.md
@@ -3,7 +3,7 @@
 ## 重要提交和发布
 
 1. WeightV2 的开发更新
- 1) [将 pallet-contracts 适配到 WeightV2](https://github.com/paritytech/substrate/pull/12421)
+ 1️⃣ [将 pallet-contracts 适配到 WeightV2](https://github.com/paritytech/substrate/pull/12421)
     * pallet-contracts 为了与新重量兼容，需要进行一些更改。
     消除 ContractAccessWeight
     这是一种用于模拟加载合约产生的巨大 PoV 影响的解决方法。现在通过将设置proof_size为已加载合约的大小来替换它。这是一个低估，但整个系统只是为了防止最严重的违规者。无论如何都缺少其他任何东西的收费，并且会在以后出现。
@@ -14,7 +14,7 @@
     * 修复兼容性外在
     在添加 2D 权重时，添加了 *_old_weightcompat extrinsics 以允许仍然解码存储中的 extrinsics。但是，它们也设置 proof_size 为0使它们无用。此 PR 设置了一些合理的默认值，以便它们继续工作。此外，还删除了文档和代码中的重复内容。
 
-  2) [合约: 将 dry-run runtime APIs 适配到 WeightV2](https://github.com/paritytech/substrate/pull/12429)
+  2️⃣ [合约: 将 dry-run runtime APIs 适配到 WeightV2](https://github.com/paritytech/substrate/pull/12429)
     * 运行时 API 中接受Weight，以便在proof_size空运行时可以通过。
     * 此外，还将参数设为可选，以便运行时可以选择合理的默认值。这样做时，将运行时 api 移动到主 crate 中。由于不再有 RPC 使用它，不需要它在自己的 crate 中。（注意：不兼容polkadot-v0.9.31及更高版本的 Substrate）
 

--- a/archive/2022_10.md
+++ b/archive/2022_10.md
@@ -1,0 +1,95 @@
+# 2022.10 - Substrate 技术更新速递
+
+## 重要提交和发布
+
+1. WeightV2 的开发更新
+  [将 pallet-contracts 适配到 WeightV2](https://github.com/paritytech/substrate/pull/12421)
+    * pallet-contracts 为了与新重量兼容，需要进行一些更改。
+    消除 ContractAccessWeight
+    这是一种用于模拟加载合约产生的巨大 PoV 影响的解决方法。现在通过将设置proof_size为已加载合约的大小来替换它。这是一个低估，但整个系统只是为了防止最严重的违规者。无论如何都缺少其他任何东西的收费，并且会在以后出现。
+    * Weight 从空运行中返回整个结构
+    试运行现在包括，proof_size 以便客户可以使用它来了解 proof_size 事务将消耗多少。
+    * 修复合约间调用
+    seal_call 并且 seal_instantiate 只允许设置一维权重。最终我们需要添加这些的新版本。但是旧版本也需要修复。当前行为是设置 proof_size 为0那个不是一个好的默认值。它会阻止被调用者做任何有用的事情。此 PR 将其设置 proof_size 为“继承”，这允许它使用总体限制中所有剩余的证明大小。
+    * 修复兼容性外在
+    在添加 2D 权重时，添加了 *_old_weightcompat extrinsics 以允许仍然解码存储中的 extrinsics。但是，它们也设置 proof_size 为0使它们无用。此 PR 设置了一些合理的默认值，以便它们继续工作。此外，还删除了文档和代码中的重复内容。
+
+   [合约: 将 dry-run runtime APIs 适配到 WeightV2](https://github.com/paritytech/substrate/pull/12429)
+    * 运行时 API 中接受Weight，以便在proof_size空运行时可以通过。
+    * 此外，还将参数设为可选，以便运行时可以选择合理的默认值。这样做时，将运行时 api 移动到主 crate 中。由于不再有 RPC 使用它，不需要它在自己的 crate 中。（注意：不兼容polkadot-v0.9.31及更高版本的 Substrate）
+
+2. Beefy协议的更新
+   [添加可插入的 BEEFY 荷载构造函数](https://github.com/paritytech/substrate/pull/12428)
+    * 实例化 BEEFY 客户端，将 MmrRootProvider 作为 PayloadProvider - BEEFY 将对 mmr 根部作为有效载荷进行投票。
+   
+   [服务：使用 MmrRootProvider 作为自定义 BEEFY 有效荷载提供程序](https://github.com/paritytech/polkadot/pull/6112)
+    * 允许使用自定义的 PayloadProviders 配置投票者，从而支持任何一切作为 BEEFY 的荷载。
+
+   [简化 pallet-beefy-mmr 的哈希值](https://github.com/paritytech/substrate/pull/12393)
+    * 重新使用 sp_runtime::traits::Hash，而不是为 Beefy 定义一个新的 Hasher 特质。
+  
+3. [Polkadot发布v0.9.30版本](https://github.com/paritytech/polkadot/releases/tag/v0.9.30): 本次发布等级为低优先级, 可以再方便时升级。摆脱历史上的深度存储，同时使得自动存储存款能够抵御存款价格的变化。
+
+4. [添加 DefensiveTruncateFrom](https://github.com/paritytech/substrate/pull/12515)
+    * 引入 defensive_truncate_from trait函数，在 TryFrom 因长度限制而失败时进行防御性截断。举例：
+    use frame_support::{BoundedVec, traits::DefensiveTruncateFrom};
+    use sp_runtime::traits::ConstU32;
+
+    let unbound = vec![1, 2, 3];
+    let bound = BoundedVec::<u8, ConstU32<2>>::defensive_truncate_from(unbound);
+
+    assert_eq!(bound, vec![1, 2]); // Truncated to two elements.
+
+    * 补充:
+    TruncateFrom trait and implementation for BoundedVec+BoundedSlice
+    DefensiveTruncateFrom trait
+    Debug impl for BoundedSlice
+    PartialEq<&'a [T]> impl for BoundedSlice
+
+    * 变化:
+    Error type of TryFrom<&'a [T]> for BoundedSlice from () to &[T] analogous to BoundedVec
+
+5. [移除 CountedStorageMap 上不必要的 Clone 特质边界](https://github.com/paritytech/substrate/pull/12402)
+    * 这个 PR 简单地删除了 CountedStorageMap 中一些方法上不必要的 Clone 特征界线。
+
+6. [修复 Weight::is_zero](https://github.com/paritytech/substrate/pull/12396)
+    * 这里缺少 proof_size。让我们选择 a future proof 的实现。
+
+7. [注册者: 避免在 provide_judgement 里使用 freebies](https://github.com/paritytech/substrate/pull/12465)
+    * Gavin Wood 提出在 providence_judgement 中，评估 repatriate_reserved 的返回值，如果失败，就不存储判决书。注册者仍然要支付费用，而没有得到任何补偿，但至少用户不会免费得到一个确认的身份。此 PR 解决了这个问题并测试通过。
+
+## 设计方案和问题讨论
+
+   [重构一个有测试目的分叉网络](https://github.com/paritytech/substrate/issues/12442)
+   * xlc 提议想从最新高度分叉一个中继链或平行链来进行测试。以太坊有很多非常好的工具链，允许开发人员拥有一个本地分叉 Eth 主网用于测试和实验目的。我们可以改进 try-runtime 以与手动密封集成，这样我们就可以拥有主网的即时分叉，并能够向其提交交易以进行测试。它还应该实现 RPC 方法，以便我们可以查询分叉网络的链上状态。
+   * xlc 建议从头开始构建一个新的测试节点会更容易。我们总是可以从 smoldot/substrate 中提取组件，例如 WasmExecutor，以避免过多的重复代码。这是他的设计草案：https ://hackmd.io/VWG4_1rkSAaRl5KtZup_Pw
+
+   [Polkadot 论坛上有一个关于探索节点存储和 extrinsics 的替代 UI 的讨论](https://forum.polkadot.network/t/alternative-ui-for-exploring-node-storage-and-extrinsics/774)
+   * 它使用节点的元数据来构建节点的 "pallet "视图，而不是像polkadot.js那样将其分门别类。
+
+
+## 文档和资料
+
+   [第一条平行链成功从 Kusama 迁移到 Polkadot](https://polkadot.network/blog/first-parachain-successfully-migrates-from-kusama-to-polkadot/) 
+   * 10 月 3 日，KILT 协议创造了历史，成为第一个完成从 Kusama 中继链到 Polkadot 中继链的完全迁移的平行链。除了标志着一个重要的技术里程碑之外，迁移还代表了平行链从 Kusama 升级到 Polkadot 的第一个实例。
+
+   [Polkadot 路线图综述](https://polkadot.network/blog/polkadot-roadmap-roundup/ )
+   * 其中包括了异步支持、平行线程、XCM v3、框架：Weights V2、治理改革等等。
+
+   [Polkadot blockspace](https://www.rob.tech/polkadot-blockspace-over-blockchains/)
+   * Polkadot联合创始人发布博客文章，分享观点“以区块空间为中心的架构将胜过以区块链为中心的架构”。同时 Gavin 也表示，“区块空间是一个有用的抽象，它为链真正提供的产品提供了一个清晰的概念。Polkadot blockspace 结合了质量、灵活性，以及我们新的 Exotic Scheduling 设施，具有无与伦比的经济效率。” 
+
+## 技术生态和社区
+   * Substrate 入门课程第十期正在招募: 由Oneblock 和 Parity 联合出品的 Substrate 区块链应用开发入门课已经开设了9期，获得了近28000名开发者的关注，课程共有3000余位开发者报名参加，获得了大家的一致好评。第十期入门课程即将开课, [报名链接](https://jhp.xet.tech/s/2eBbfX)
+
+   [入场 Web3 他们后悔了吗？加密领域多赛道初创者漫谈](https://mp.weixin.qq.com/s/_s40iHy1YXV7R5aZgZbZWw) 
+   * 第四期“黑客松之后，他们去哪儿了”专访直击开发者关切的 Web3 发展前景问题，OneBlock 邀请到 Parallel、Web3Go、Web3Games、NonceGeek、Melody、Echodao 六位初创项目创始人或核心成员，结合他们的 Web3er 之旅的实践经历，展开深度漫谈。
+
+
+## 跨链协议
+   [XCM runtime api](https://github.com/paritytech/polkadot/pull/6156)
+   * 添加 xcm-runtime-api 定义运行时 api 以检索有用的运行时相关 xcm 数据的包。目前，该特征包含：
+     加权消息的函数weight_message
+     将 ML 转换为帐户的功能convert_location
+     计算为一定重量和资产支付的费用的函数：calculate_concrete_asset_fee
+     预计 XCM 中权重的变化我创建了一个VersionedWeight枚举，以便 API 不会在发生此变化后中断。另一种选择是删除它，并在 XCM V3 合并后简单地增加 API 版本。

--- a/archive/2022_10.md
+++ b/archive/2022_10.md
@@ -14,9 +14,8 @@
     * 修复兼容性外在
     在添加 2D 权重时，添加了 *_old_weightcompat extrinsics 以允许仍然解码存储中的 extrinsics。但是，它们也设置 proof_size 为0使它们无用。此 PR 设置了一些合理的默认值，以便它们继续工作。此外，还删除了文档和代码中的重复内容。
 
-  2️⃣ [合约: 将 dry-run runtime APIs 适配到 WeightV2](https://github.com/paritytech/substrate/pull/12429)
-    * 运行时 API 中接受 Weight，以便在 proof_size 空运行时可以通过。
-    * 此外，还将参数设为可选，以便运行时可以选择合理的默认值。这样做时，将运行时 api 移动到主 crate 中。由于不再有 RPC 使用它，不需要它在自己的 crate 中。（注意：不兼容 polkadot-v0.9.31 及更高版本的 Substrate ）
+  2️⃣ [合约: 将 dry-run runtime APIs 适配到 WeightV2](https://github.com/paritytech/substrate/pull/12429) * 运行时 API 中接受 Weight，以便在 proof_size 空运行时可以通过。
+  * 此外，还将参数设为可选，以便运行时可以选择合理的默认值。这样做时，将运行时 api 移动到主 crate 中。由于不再有 RPC 使用它，不需要它在自己的 crate 中。（注意：不兼容 polkadot-v0.9.31 及更高版本的 Substrate ）
  
 2. Beefy 协议的更新
    [添加可插入的 BEEFY 荷载构造函数](https://github.com/paritytech/substrate/pull/12428)

--- a/archive/2022_10.md
+++ b/archive/2022_10.md
@@ -3,6 +3,7 @@
 ## 重要提交和发布
 
 1. WeightV2 的开发更新
+
   [将 pallet-contracts 适配到 WeightV2](https://github.com/paritytech/substrate/pull/12421)
     * pallet-contracts 为了与新重量兼容，需要进行一些更改。
     消除 ContractAccessWeight

--- a/archive/2022_10.md
+++ b/archive/2022_10.md
@@ -80,7 +80,7 @@
    * Polkadot联合创始人发布博客文章，分享观点“以区块空间为中心的架构将胜过以区块链为中心的架构”。同时 Gavin 也表示，“区块空间是一个有用的抽象，它为链真正提供的产品提供了一个清晰的概念。Polkadot blockspace 结合了质量、灵活性，以及我们新的 Exotic Scheduling 设施，具有无与伦比的经济效率。” 
 
 ## 技术生态和社区
-   * Substrate 入门课程第十期正在招募: 由Oneblock 和 Parity 联合出品的 Substrate 区块链应用开发入门课已经开设了9期，获得了近28000名开发者的关注，课程共有3000余位开发者报名参加，获得了大家的一致好评。第十期入门课程即将开课, [报名链接](https://jhp.xet.tech/s/2eBbfX)
+   * [Substrate 入门课程第十期正在招募中](https://jhp.xet.tech/s/2eBbfX) 由Oneblock 和 Parity 联合出品的 Substrate 区块链应用开发入门课已经开设了9期，获得了近28000名开发者的关注，课程共有3000余位开发者报名参加，获得了大家的一致好评。
 
    [入场 Web3 他们后悔了吗？加密领域多赛道初创者漫谈](https://mp.weixin.qq.com/s/_s40iHy1YXV7R5aZgZbZWw) 
    * 第四期“黑客松之后，他们去哪儿了”专访直击开发者关切的 Web3 发展前景问题，OneBlock 邀请到 Parallel、Web3Go、Web3Games、NonceGeek、Melody、Echodao 六位初创项目创始人或核心成员，结合他们的 Web3er 之旅的实践经历，展开深度漫谈。

--- a/archive/2022_10.md
+++ b/archive/2022_10.md
@@ -3,7 +3,7 @@
 ## 重要提交和发布
 
 1. WeightV2 的开发更新
-  [将 pallet-contracts 适配到 WeightV2](https://github.com/paritytech/substrate/pull/12421)
+ 1) [将 pallet-contracts 适配到 WeightV2](https://github.com/paritytech/substrate/pull/12421)
     * pallet-contracts 为了与新重量兼容，需要进行一些更改。
     消除 ContractAccessWeight
     这是一种用于模拟加载合约产生的巨大 PoV 影响的解决方法。现在通过将设置proof_size为已加载合约的大小来替换它。这是一个低估，但整个系统只是为了防止最严重的违规者。无论如何都缺少其他任何东西的收费，并且会在以后出现。
@@ -14,7 +14,7 @@
     * 修复兼容性外在
     在添加 2D 权重时，添加了 *_old_weightcompat extrinsics 以允许仍然解码存储中的 extrinsics。但是，它们也设置 proof_size 为0使它们无用。此 PR 设置了一些合理的默认值，以便它们继续工作。此外，还删除了文档和代码中的重复内容。
 
-   [合约: 将 dry-run runtime APIs 适配到 WeightV2](https://github.com/paritytech/substrate/pull/12429)
+  2) [合约: 将 dry-run runtime APIs 适配到 WeightV2](https://github.com/paritytech/substrate/pull/12429)
     * 运行时 API 中接受Weight，以便在proof_size空运行时可以通过。
     * 此外，还将参数设为可选，以便运行时可以选择合理的默认值。这样做时，将运行时 api 移动到主 crate 中。由于不再有 RPC 使用它，不需要它在自己的 crate 中。（注意：不兼容polkadot-v0.9.31及更高版本的 Substrate）
 

--- a/archive/2022_10.md
+++ b/archive/2022_10.md
@@ -3,7 +3,7 @@
 ## 重要提交和发布
 
 1. WeightV2 的开发更新
- 1️⃣ [将 pallet-contracts 适配到 WeightV2](https://github.com/paritytech/substrate/pull/12421)
+1️⃣ [将 pallet-contracts 适配到 WeightV2](https://github.com/paritytech/substrate/pull/12421)
     * pallet-contracts 为了与新重量兼容，需要进行一些更改。
     消除 ContractAccessWeight
     这是一种用于模拟加载合约产生的巨大 PoV 影响的解决方法。现在通过将设置proof_size为已加载合约的大小来替换它。这是一个低估，但整个系统只是为了防止最严重的违规者。无论如何都缺少其他任何东西的收费，并且会在以后出现。

--- a/archive/2022_10.md
+++ b/archive/2022_10.md
@@ -60,31 +60,26 @@
 
 ## 设计方案和问题讨论
 
-   [重构一个有测试目的分叉网络](https://github.com/paritytech/substrate/issues/12442)
+ 1. [重构一个有测试目的分叉网络](https://github.com/paritytech/substrate/issues/12442)
    * xlc 提议想从最新高度分叉一个中继链或平行链来进行测试。以太坊有很多非常好的工具链，允许开发人员拥有一个本地分叉 Eth 主网用于测试和实验目的。我们可以改进 try-runtime 以与手动密封集成，这样我们就可以拥有主网的即时分叉，并能够向其提交交易以进行测试。它还应该实现 RPC 方法，以便我们可以查询分叉网络的链上状态。
    * xlc 建议从头开始构建一个新的测试节点会更容易。我们总是可以从 smoldot/substrate 中提取组件，例如 WasmExecutor，以避免过多的重复代码。这是他的设计草案：https ://hackmd.io/VWG4_1rkSAaRl5KtZup_Pw
 
-   [Polkadot 论坛上有一个关于探索节点存储和 extrinsics 的替代 UI 的讨论](https://forum.polkadot.network/t/alternative-ui-for-exploring-node-storage-and-extrinsics/774)
+ 2. [Polkadot 论坛上有一个关于探索节点存储和 extrinsics 的替代 UI 的讨论](https://forum.polkadot.network/t/alternative-ui-for-exploring-node-storage-and-extrinsics/774)
    * 它使用节点的元数据来构建节点的 "pallet "视图，而不是像polkadot.js那样将其分门别类。
 
 
 ## 文档和资料
 
-   [第一条平行链成功从 Kusama 迁移到 Polkadot](https://polkadot.network/blog/first-parachain-successfully-migrates-from-kusama-to-polkadot/) 
-   * 10 月 3 日，KILT 协议创造了历史，成为第一个完成从 Kusama 中继链到 Polkadot 中继链的完全迁移的平行链。除了标志着一个重要的技术里程碑之外，迁移还代表了平行链从 Kusama 升级到 Polkadot 的第一个实例。
+   * [第一条平行链成功从 Kusama 迁移到 Polkadot](https://polkadot.network/blog/first-parachain-successfully-migrates-from-kusama-to-polkadot/) 10 月 3 日，KILT 协议创造了历史，成为第一个完成从 Kusama 中继链到 Polkadot 中继链的完全迁移的平行链。除了标志着一个重要的技术里程碑之外，迁移还代表了平行链从 Kusama 升级到 Polkadot 的第一个实例。
 
-   [Polkadot 路线图综述](https://polkadot.network/blog/polkadot-roadmap-roundup/ )
-   * 其中包括了异步支持、平行线程、XCM v3、框架：Weights V2、治理改革等等。
+   * [Polkadot 路线图综述](https://polkadot.network/blog/polkadot-roadmap-roundup/) 其中包括了异步支持、平行线程、XCM v3、框架：Weights V2、治理改革等等。
 
-   [Polkadot blockspace](https://www.rob.tech/polkadot-blockspace-over-blockchains/)
-   * Polkadot联合创始人发布博客文章，分享观点“以区块空间为中心的架构将胜过以区块链为中心的架构”。同时 Gavin 也表示，“区块空间是一个有用的抽象，它为链真正提供的产品提供了一个清晰的概念。Polkadot blockspace 结合了质量、灵活性，以及我们新的 Exotic Scheduling 设施，具有无与伦比的经济效率。” 
+   * [Polkadot blockspace](https://www.rob.tech/polkadot-blockspace-over-blockchains/) Polkadot联合创始人发布博客文章，分享观点“以区块空间为中心的架构将胜过以区块链为中心的架构”。同时 Gavin 也表示，“区块空间是一个有用的抽象，它为链真正提供的产品提供了一个清晰的概念。Polkadot blockspace 结合了质量、灵活性，以及我们新的 Exotic Scheduling 设施，具有无与伦比的经济效率。” 
 
 ## 技术生态和社区
    * [Substrate 入门课程第十期正在招募中](https://jhp.xet.tech/s/2eBbfX) 由Oneblock 和 Parity 联合出品的 Substrate 区块链应用开发入门课已经开设了9期，获得了近28000名开发者的关注，课程共有3000余位开发者报名参加，获得了大家的一致好评。
 
-   [入场 Web3 他们后悔了吗？加密领域多赛道初创者漫谈](https://mp.weixin.qq.com/s/_s40iHy1YXV7R5aZgZbZWw) 
-   * 第四期“黑客松之后，他们去哪儿了”专访直击开发者关切的 Web3 发展前景问题，OneBlock 邀请到 Parallel、Web3Go、Web3Games、NonceGeek、Melody、Echodao 六位初创项目创始人或核心成员，结合他们的 Web3er 之旅的实践经历，展开深度漫谈。
-
+   * [入场 Web3 他们后悔了吗？加密领域多赛道初创者漫谈](https://mp.weixin.qq.com/s/_s40iHy1YXV7R5aZgZbZWw) 第四期“黑客松之后，他们去哪儿了”专访直击开发者关切的 Web3 发展前景问题，OneBlock 邀请到 Parallel、Web3Go、Web3Games、NonceGeek、Melody、Echodao 六位初创项目创始人或核心成员，结合他们的 Web3er 之旅的实践经历，展开深度漫谈。
 
 ## 跨链协议
    [XCM runtime api](https://github.com/paritytech/polkadot/pull/6156)

--- a/archive/2022_10.md
+++ b/archive/2022_10.md
@@ -16,7 +16,7 @@
 
   2️⃣ [合约: 将 dry-run runtime APIs 适配到 WeightV2](https://github.com/paritytech/substrate/pull/12429)
     * 运行时 API 中接受 Weight，以便在 proof_size 空运行时可以通过。
-    * 此外，还将参数设为可选，以便运行时可以选择合理的默认值。这样做时，将运行时 api 移动到主 crate 中。由于不再有 RPC 使用它，不需要它在自己的 crate 中。（注意：不兼容polkadot-v0.9.31 及更高版本的 Substrate）
+    * 此外，还将参数设为可选，以便运行时可以选择合理的默认值。这样做时，将运行时 api 移动到主 crate 中。由于不再有 RPC 使用它，不需要它在自己的 crate 中。（注意：不兼容 polkadot-v0.9.31 及更高版本的 Substrate ）
  
 2. Beefy 协议的更新
    [添加可插入的 BEEFY 荷载构造函数](https://github.com/paritytech/substrate/pull/12428)

--- a/archive/2022_10.md
+++ b/archive/2022_10.md
@@ -15,10 +15,10 @@
     在添加 2D 权重时，添加了 *_old_weightcompat extrinsics 以允许仍然解码存储中的 extrinsics。但是，它们也设置 proof_size 为0使它们无用。此 PR 设置了一些合理的默认值，以便它们继续工作。此外，还删除了文档和代码中的重复内容。
 
   2️⃣ [合约: 将 dry-run runtime APIs 适配到 WeightV2](https://github.com/paritytech/substrate/pull/12429)
-    * 运行时 API 中接受Weight，以便在proof_size空运行时可以通过。
-    * 此外，还将参数设为可选，以便运行时可以选择合理的默认值。这样做时，将运行时 api 移动到主 crate 中。由于不再有 RPC 使用它，不需要它在自己的 crate 中。（注意：不兼容polkadot-v0.9.31及更高版本的 Substrate）
-
-2. Beefy协议的更新
+    * 运行时 API 中接受 Weight，以便在 proof_size 空运行时可以通过。
+    * 此外，还将参数设为可选，以便运行时可以选择合理的默认值。这样做时，将运行时 api 移动到主 crate 中。由于不再有 RPC 使用它，不需要它在自己的 crate 中。（注意：不兼容polkadot-v0.9.31 及更高版本的 Substrate）
+ 
+2. Beefy 协议的更新
    [添加可插入的 BEEFY 荷载构造函数](https://github.com/paritytech/substrate/pull/12428)
     * 实例化 BEEFY 客户端，将 MmrRootProvider 作为 PayloadProvider - BEEFY 将对 mmr 根部作为有效载荷进行投票。
    
@@ -28,7 +28,7 @@
    [简化 pallet-beefy-mmr 的哈希值](https://github.com/paritytech/substrate/pull/12393)
     * 重新使用 sp_runtime::traits::Hash，而不是为 Beefy 定义一个新的 Hasher 特质。
   
-3. [Polkadot发布v0.9.30版本](https://github.com/paritytech/polkadot/releases/tag/v0.9.30): 本次发布等级为低优先级, 可以再方便时升级。摆脱历史上的深度存储，同时使得自动存储存款能够抵御存款价格的变化。
+3. [Polkadot 发布 v0.9.30 版本](https://github.com/paritytech/polkadot/releases/tag/v0.9.30): 本次发布等级为低优先级, 可以再方便时升级。摆脱历史上的深度存储，同时使得自动存储存款能够抵御存款价格的变化。
 
 4. [添加 DefensiveTruncateFrom](https://github.com/paritytech/substrate/pull/12515)
     * 引入 defensive_truncate_from trait函数，在 TryFrom 因长度限制而失败时进行防御性截断。举例：

--- a/archive/2022_10.md
+++ b/archive/2022_10.md
@@ -3,7 +3,6 @@
 ## 重要提交和发布
 
 1. WeightV2 的开发更新
-
   [将 pallet-contracts 适配到 WeightV2](https://github.com/paritytech/substrate/pull/12421)
     * pallet-contracts 为了与新重量兼容，需要进行一些更改。
     消除 ContractAccessWeight

--- a/archive/2022_10.md
+++ b/archive/2022_10.md
@@ -14,7 +14,8 @@
     * 修复兼容性外在
     在添加 2D 权重时，添加了 *_old_weightcompat extrinsics 以允许仍然解码存储中的 extrinsics。但是，它们也设置 proof_size 为0使它们无用。此 PR 设置了一些合理的默认值，以便它们继续工作。此外，还删除了文档和代码中的重复内容。
 
-  2️⃣ [合约: 将 dry-run runtime APIs 适配到 WeightV2](https://github.com/paritytech/substrate/pull/12429) * 运行时 API 中接受 Weight，以便在 proof_size 空运行时可以通过。
+  2️⃣ [合约: 将 dry-run runtime APIs 适配到 WeightV2](https://github.com/paritytech/substrate/pull/12429) 
+  * 运行时 API 中接受 Weight，以便在 proof_size 空运行时可以通过。
   * 此外，还将参数设为可选，以便运行时可以选择合理的默认值。这样做时，将运行时 api 移动到主 crate 中。由于不再有 RPC 使用它，不需要它在自己的 crate 中。（注意：不兼容 polkadot-v0.9.31 及更高版本的 Substrate ）
  
 2. Beefy 协议的更新


### PR DESCRIPTION
# 2022.10 - Substrate 技术更新速递

## 重要提交和发布

1. WeightV2 的开发更新
1️⃣ [将 pallet-contracts 适配到 WeightV2](https://github.com/paritytech/substrate/pull/12421)
    * pallet-contracts 为了与新重量兼容，需要进行一些更改。
    消除 ContractAccessWeight
    这是一种用于模拟加载合约产生的巨大 PoV 影响的解决方法。现在通过将设置proof_size为已加载合约的大小来替换它。这是一个低估，但整个系统只是为了防止最严重的违规者。无论如何都缺少其他任何东西的收费，并且会在以后出现。
    * Weight 从空运行中返回整个结构
    试运行现在包括，proof_size 以便客户可以使用它来了解 proof_size 事务将消耗多少。
    * 修复合约间调用
    seal_call 并且 seal_instantiate 只允许设置一维权重。最终我们需要添加这些的新版本。但是旧版本也需要修复。当前行为是设置 proof_size 为0那个不是一个好的默认值。它会阻止被调用者做任何有用的事情。此 PR 将其设置 proof_size 为“继承”，这允许它使用总体限制中所有剩余的证明大小。
    * 修复兼容性外在
    在添加 2D 权重时，添加了 *_old_weightcompat extrinsics 以允许仍然解码存储中的 extrinsics。但是，它们也设置 proof_size 为0使它们无用。此 PR 设置了一些合理的默认值，以便它们继续工作。此外，还删除了文档和代码中的重复内容。

  2️⃣ [合约: 将 dry-run runtime APIs 适配到 WeightV2](https://github.com/paritytech/substrate/pull/12429) 
  * 运行时 API 中接受 Weight，以便在 proof_size 空运行时可以通过。
  * 此外，还将参数设为可选，以便运行时可以选择合理的默认值。这样做时，将运行时 api 移动到主 crate 中。由于不再有 RPC 使用它，不需要它在自己的 crate 中。（注意：不兼容 polkadot-v0.9.31 及更高版本的 Substrate ）

2. Beefy 协议的更新
   [添加可插入的 BEEFY 荷载构造函数](https://github.com/paritytech/substrate/pull/12428)
    * 实例化 BEEFY 客户端，将 MmrRootProvider 作为 PayloadProvider - BEEFY 将对 mmr 根部作为有效载荷进行投票。

   [服务：使用 MmrRootProvider 作为自定义 BEEFY 有效荷载提供程序](https://github.com/paritytech/polkadot/pull/6112)
    * 允许使用自定义的 PayloadProviders 配置投票者，从而支持任何一切作为 BEEFY 的荷载。

   [简化 pallet-beefy-mmr 的哈希值](https://github.com/paritytech/substrate/pull/12393)
    * 重新使用 sp_runtime::traits::Hash，而不是为 Beefy 定义一个新的 Hasher 特质。

3. [Polkadot 发布 v0.9.30 版本](https://github.com/paritytech/polkadot/releases/tag/v0.9.30): 本次发布等级为低优先级, 可以再方便时升级。摆脱历史上的深度存储，同时使得自动存储存款能够抵御存款价格的变化。

4. [添加 DefensiveTruncateFrom](https://github.com/paritytech/substrate/pull/12515)
    * 引入 defensive_truncate_from trait函数，在 TryFrom 因长度限制而失败时进行防御性截断。举例：
    use frame_support::{BoundedVec, traits::DefensiveTruncateFrom};
    use sp_runtime::traits::ConstU32;

    let unbound = vec![1, 2, 3];
    let bound = BoundedVec::<u8, ConstU32<2>>::defensive_truncate_from(unbound);

    assert_eq!(bound, vec![1, 2]); // Truncated to two elements.

    * 补充:
    TruncateFrom trait and implementation for BoundedVec+BoundedSlice
    DefensiveTruncateFrom trait
    Debug impl for BoundedSlice
    PartialEq<&'a [T]> impl for BoundedSlice

    * 变化:
    Error type of TryFrom<&'a [T]> for BoundedSlice from () to &[T] analogous to BoundedVec

5. [移除 CountedStorageMap 上不必要的 Clone 特质边界](https://github.com/paritytech/substrate/pull/12402)
    * 这个 PR 简单地删除了 CountedStorageMap 中一些方法上不必要的 Clone 特征界线。

6. [修复 Weight::is_zero](https://github.com/paritytech/substrate/pull/12396)
    * 这里缺少 proof_size。让我们选择 a future proof 的实现。

7. [注册者: 避免在 provide_judgement 里使用 freebies](https://github.com/paritytech/substrate/pull/12465)
    * Gavin Wood 提出在 providence_judgement 中，评估 repatriate_reserved 的返回值，如果失败，就不存储判决书。注册者仍然要支付费用，而没有得到任何补偿，但至少用户不会免费得到一个确认的身份。此 PR 解决了这个问题并测试通过。

## 设计方案和问题讨论

 1. [重构一个有测试目的分叉网络](https://github.com/paritytech/substrate/issues/12442)
   * xlc 提议想从最新高度分叉一个中继链或平行链来进行测试。以太坊有很多非常好的工具链，允许开发人员拥有一个本地分叉 Eth 主网用于测试和实验目的。我们可以改进 try-runtime 以与手动密封集成，这样我们就可以拥有主网的即时分叉，并能够向其提交交易以进行测试。它还应该实现 RPC 方法，以便我们可以查询分叉网络的链上状态。
   * xlc 建议从头开始构建一个新的测试节点会更容易。我们总是可以从 smoldot/substrate 中提取组件，例如 WasmExecutor，以避免过多的重复代码。这是他的设计草案：https ://hackmd.io/VWG4_1rkSAaRl5KtZup_Pw

 2. [Polkadot 论坛上有一个关于探索节点存储和 extrinsics 的替代 UI 的讨论](https://forum.polkadot.network/t/alternative-ui-for-exploring-node-storage-and-extrinsics/774)
   * 它使用节点的元数据来构建节点的 "pallet "视图，而不是像polkadot.js那样将其分门别类。


## 文档和资料

   * [第一条平行链成功从 Kusama 迁移到 Polkadot](https://polkadot.network/blog/first-parachain-successfully-migrates-from-kusama-to-polkadot/) 10 月 3 日，KILT 协议创造了历史，成为第一个完成从 Kusama 中继链到 Polkadot 中继链的完全迁移的平行链。除了标志着一个重要的技术里程碑之外，迁移还代表了平行链从 Kusama 升级到 Polkadot 的第一个实例。

   * [Polkadot 路线图综述](https://polkadot.network/blog/polkadot-roadmap-roundup/) 其中包括了异步支持、平行线程、XCM v3、框架：Weights V2、治理改革等等。

   * [Polkadot blockspace](https://www.rob.tech/polkadot-blockspace-over-blockchains/) Polkadot联合创始人发布博客文章，分享观点“以区块空间为中心的架构将胜过以区块链为中心的架构”。同时 Gavin 也表示，“区块空间是一个有用的抽象，它为链真正提供的产品提供了一个清晰的概念。Polkadot blockspace 结合了质量、灵活性，以及我们新的 Exotic Scheduling 设施，具有无与伦比的经济效率。” 

## 技术生态和社区
   * [Substrate 入门课程第十期正在招募中](https://jhp.xet.tech/s/2eBbfX) 由Oneblock 和 Parity 联合出品的 Substrate 区块链应用开发入门课已经开设了9期，获得了近28000名开发者的关注，课程共有3000余位开发者报名参加，获得了大家的一致好评。

   * [入场 Web3 他们后悔了吗？加密领域多赛道初创者漫谈](https://mp.weixin.qq.com/s/_s40iHy1YXV7R5aZgZbZWw) 第四期“黑客松之后，他们去哪儿了”专访直击开发者关切的 Web3 发展前景问题，OneBlock 邀请到 Parallel、Web3Go、Web3Games、NonceGeek、Melody、Echodao 六位初创项目创始人或核心成员，结合他们的 Web3er 之旅的实践经历，展开深度漫谈。

## 跨链协议
   [XCM runtime api](https://github.com/paritytech/polkadot/pull/6156)
   * 添加 xcm-runtime-api 定义运行时 api 以检索有用的运行时相关 xcm 数据的包。目前，该特征包含：
     加权消息的函数weight_message
     将 ML 转换为帐户的功能convert_location
     计算为一定重量和资产支付的费用的函数：calculate_concrete_asset_fee
     预计 XCM 中权重的变化我创建了一个VersionedWeight枚举，以便 API 不会在发生此变化后中断。另一种选择是删除它，并在 XCM V3 合并后简单地增加 API 版本。